### PR TITLE
JWT Access Token 만료에 따른 Refresh Token 재발급 로직 수정

### DIFF
--- a/server/src/main/java/com/ssafy/living_spot/auth/filter/JwtAuthenticationFilter.java
+++ b/server/src/main/java/com/ssafy/living_spot/auth/filter/JwtAuthenticationFilter.java
@@ -66,14 +66,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             String accessToken = extractAccessToken(request);
             log.info("Access Token: {}", accessToken);
             if (accessToken != null) {
-                jwtTokenValidator.validateToken(accessToken);
                 // Access Token이 만료되었는지 확인
                 if (!jwtUtil.isExpired(accessToken)) {
                     //Access Token이 유효한 경우
+                    jwtTokenValidator.validateToken(accessToken);
+
                     processValidAccessToken(accessToken);
                 } else {
                     //Access Token이 만료된 경우
-                    System.out.println("Access Token is expired");
                     processExpiredAccessToken(request, response);
                 }
             }
@@ -109,7 +109,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 null,
                 Collections.singleton(new SimpleGrantedAuthority("ROLE_" + role))
         );
-
         SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 
@@ -122,7 +121,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         if (refreshTokenCookie.isPresent()) {
             String refreshToken = refreshTokenCookie.get().getValue();
-
             jwtTokenValidator.validateToken(refreshToken);
 
             // Refresh Token이 만료되지 않았는지 확인

--- a/server/src/main/java/com/ssafy/living_spot/auth/jwt/component/JwtUtil.java
+++ b/server/src/main/java/com/ssafy/living_spot/auth/jwt/component/JwtUtil.java
@@ -6,6 +6,7 @@ import com.ssafy.living_spot.auth.dto.MemberTokenInfo;
 import com.ssafy.living_spot.auth.dto.response.JwtToken;
 import com.ssafy.living_spot.common.util.RedisUtil;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import java.util.Date;
 import lombok.RequiredArgsConstructor;
@@ -61,7 +62,13 @@ public class JwtUtil {
     }
 
     public Boolean isExpired(String token) {
-        return getClaims(token).getExpiration().before(new Date());
+        try {
+            Date expiration = getClaims(token).getExpiration();
+            return expiration.before(new Date());
+        } catch (ExpiredJwtException e) {
+            // 토큰이 만료되었음을 명시적으로 true로 반환
+            return true;
+        }
     }
 
     private Claims getClaims(String token) {


### PR DESCRIPTION
## 📣 Related Issue

<!-- 관련 이슈를 적어주세요. -->

- close #22

## 📝 Summary

<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
 - getClaims 메서드에서 만료 시간을 알아서 예외처리 하는 것때문에 Access Token이 만료되는 경우에 Refresh Token의 여부와 상관없이 예외를 처리하는 것때문에 만료 여부와 상관없이 true를 return 시키는 로직으로 변경

- Https 설정을 하지 않았기 때문에, Secure 설정을 한 refresh token을 검사할 수가 없는데, 이는 추후에 수정하겠습ㄴ니다.

## 🙏 Question & PR point

<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

## 📬 Reference

<!-- 참고한 코드의 출처를 작성해주세요 -->
